### PR TITLE
fix: Set package name from toml

### DIFF
--- a/.github/workflows/kit_package.yml
+++ b/.github/workflows/kit_package.yml
@@ -27,14 +27,18 @@ jobs:
         run: pip install toml
       # Use toml to get the version of the kit and store it as an environment variable
       - name: Get Kit Version
-        run: echo "KIT_VERSION=$(python -c 'import toml; print(toml.load("pyproject.toml")["project"]["version"])')" >> $GITHUB_ENV
+        run: |
+          echo "KIT_VERSION=$(python -c 'import toml; print(toml.load("pyproject.toml")["project"]["version"])')" >> $GITHUB_ENV
+          echo "KIT_NAME=$(python -c 'import toml; print(toml.load("pyproject.toml")["project"]["name"])')" >> $GITHUB_ENV
       # Package the lpk file
       - name: Package Kit
-        run: python -m scripts.build
+        run: |
+          python -m scripts.build
+          ls -l ./build
       # Create a tag release on the repository
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1.0.0
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -49,7 +53,7 @@ jobs:
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KIT_FILE_NAME: modo_kit_cental_${{ env.KIT_VERSION }}.lpk
+          KIT_FILE_NAME: ${{ env.KIT_NAME }}_${{ env.KIT_VERSION }}.lpk
         with:
           # Get the url of the checked out code
           upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
Misspelling on the package name.

This change uses the name directly from the pyproject.toml.